### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,6 +16,10 @@ class ItemsController < ApplicationController
 
   end
 
+  def index
+    @items = Item.includes(:user)
+  end
+
   private #ここからプライベートだよー
   def item_params
     params.require(:item).permit(:name, :image, :explanation, :category_id, :status_id, :prefecture_id, :delivery_price_id, :delivery_date_id, :price).merge(user_id: current_user.id)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,7 +17,7 @@ class ItemsController < ApplicationController
   end
 
   def index
-    @items = Item.includes(:user)
+    @items = Item.includes(:user).order("created_at DESC")
   end
 
   private #ここからプライベートだよー

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,0 +1,30 @@
+              <li class='list'>
+
+        <%= link_to '#' do %>
+        <div class='item-img-content'>
+
+        <%= image_tag item.image, class: "item-img" %>
+        
+                  <%# 商品が売れていればsold outを表示しましょう %>
+          <div class='sold-out'>
+            <span>Sold Out!!</span>
+          </div>
+          <%# //商品が売れていればsold outを表示しましょう %>
+
+        </div>
+        <div class='item-info'>
+          <h3 class='item-name'>
+          <%= item.name  %>
+          </h3>
+          <div class='item-price'>
+                      <span><%= item.price %>円<br><%= item.delivery_price.name %></span>
+
+            <div class='star-btn'>
+              <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
+            </div>
+          </div>
+        </div>
+        <% end %>
+              </li>
+

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,38 +127,9 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+<% if @items.any? %>
+<%= render partial: 'item', collection: @items %>
+    <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -175,9 +146,9 @@
           </div>
         </div>
         <% end %>
+            <% end %>
+
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
   <%# /商品一覧 %>


### PR DESCRIPTION
#what　
商品一覧機能の実装
〇コントローラー：indexアクションの定義
〇ビュー：部分テンプレートの作成、表示

#why
・ログインしていなくも一覧は見られるように authenticate_user!,のメソッドでindexを免除しました。
・商品存在する場合とそうでない場合で条件分岐しました。
・商品表示はアクティブハッシュからのデータも含めて表示できるようにしました。

出品されている商品がないとき

https://github.com/ricchandes/furima-39472/assets/136784375/dd868413-0dd5-40aa-bc8c-086d838f5218

出品されている商品があるとき(データは昇順

https://github.com/ricchandes/furima-39472/assets/136784375/acb61a27-ea45-4d85-b8a2-b72142c16016

)
